### PR TITLE
refactor: switch to new bootstrap format

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,10 +7,14 @@
     "python.linting.mypyEnabled": true,
     "mypy.runUsingActiveInterpreter": true,
     "python.linting.ignorePatterns": [
-        "venv/**/*.py"
+        ".venv/**/*.py"
     ],
     "cSpell.words": [
+        "Dkuk",
+        "MHUV",
         "Popen",
+        "Tgbuq",
+        "bwdty",
         "envvar",
         "fout",
         "getenv",

--- a/sidechain_cli/bridge/transfer.py
+++ b/sidechain_cli/bridge/transfer.py
@@ -230,7 +230,7 @@ def send_transfer(
         else:
             time_count += _WAIT_STEP_LENGTH
 
-        quorum = max(1, len(bridge_config.witnesses) - 1)
+        quorum = max(1, bridge_config.num_witnesses - 1)
         if attestation_count >= quorum:
             # received enough attestations for quorum
             break

--- a/sidechain_cli/misc/create_account.py
+++ b/sidechain_cli/misc/create_account.py
@@ -164,7 +164,7 @@ def create_xchain_account(
         else:
             time_count += _WAIT_STEP_LENGTH
 
-        quorum = max(1, len(bridge_config.witnesses) - 1)
+        quorum = max(1, bridge_config.num_witnesses - 1)
         if attestation_count >= quorum:
             # received enough attestations for quorum
             break

--- a/sidechain_cli/server/config/config.py
+++ b/sidechain_cli/server/config/config.py
@@ -370,7 +370,8 @@ def generate_all_configs(
             original_wallet.seed, 0, algorithm=CryptoAlgorithm.ED25519
         )
         reward_accounts.append(witness_reward_wallet.classic_address)
-        signing_wallet = Wallet.create(CryptoAlgorithm.SECP256K1)
+        wallet = Wallet.create(CryptoAlgorithm.SECP256K1)
+        signing_wallet = Wallet(wallet.seed, 0, algorithm=CryptoAlgorithm.ED25519)
         signing_accounts.append(signing_wallet.classic_address)
         ctx.invoke(
             generate_witness_config,

--- a/sidechain_cli/server/config/templates/bootstrap.jinja
+++ b/sidechain_cli/server/config/templates/bootstrap.jinja
@@ -1,11 +1,75 @@
 {
-  "locking_chain_door": {
-    "id": "{{ locking_chain_id }}",
-    "seed": "{{ locking_chain_seed }}"
+  "LockingChain": {
+    "Endpoint": {
+      "IP": "127.0.0.1",
+      "JsonRPCPort": {{ locking_node_port }}
+    },
+    "DoorAccount": {
+      "Address": "{{ locking_door_account }}",
+      "Seed": "{{ locking_door_seed }}",
+      "KeyType": "ed25519"
+    },
+    "BridgeIssue": "{{ locking_issue }}",
+    "WitnessRewardAccounts": [
+    {% for account in locking_reward_accounts %}
+      "{{ account }}"
+      {%- if not loop.last -%}
+      ,
+      {% endif %}
+    {% endfor +%}
+    ],
+    "WitnessSubmitAccounts": [
+    {% for account in locking_submit_accounts %}
+      "{{ account }}"
+      {%- if not loop.last -%}
+      ,
+      {% endif %}
+    {% endfor +%}
+    ]
   },
-  "issuing_chain_door": {
-    "id": "{{ issuing_chain_id }}",
-    "seed": "{{ issuing_chain_seed }}"
+  "IssuingChain": {
+    "Endpoint": {
+      {% if is_linux %}
+      "IP": "127.0.0.2",
+      {% else %}
+      "IP": "127.0.0.1",
+      {% endif %}
+      "JsonRPCPort": {{ issuing_node_port }}
+    },
+    "DoorAccount": {
+      "Address": "{{ issuing_door_account }}",
+      "Seed": "{{ issuing_door_seed }}",
+      "KeyType": "ed25519"
+    },
+    "BridgeIssue": "{{ issuing_issue }}",
+    "WitnessRewardAccounts": [
+    {% for account in issuing_reward_accounts %}
+      "{{ account }}"
+      {%- if not loop.last -%}
+      ,
+      {% endif %}
+    {% endfor +%}
+    ],
+    "WitnessSubmitAccounts": [
+    {% for account in issuing_submit_accounts %}
+      "{{ account }}"
+      {%- if not loop.last -%}
+      ,
+      {% endif %}
+    {% endfor +%}
+    ]
   },
-  "witness_reward_accounts": {{ witness_reward_accounts | list | tojson }}
+  "Witnesses": {
+    "SignerList": [
+    {% for account in signing_accounts %}
+      {
+        "Account": "{{ account }}",
+        "Weight": 1
+      }
+      {%- if not loop.last -%}
+      ,
+      {% endif %}
+    {% endfor +%}
+    ]
+  }
 }

--- a/sidechain_cli/server/config/templates/bootstrap.jinja
+++ b/sidechain_cli/server/config/templates/bootstrap.jinja
@@ -11,20 +11,10 @@
     },
     "BridgeIssue": "{{ locking_issue }}",
     "WitnessRewardAccounts": [
-    {% for account in locking_reward_accounts %}
-      "{{ account }}"
-      {%- if not loop.last -%}
-      ,
-      {% endif %}
-    {% endfor +%}
+      "{{ locking_reward_accounts | join("\",\n      \"") }}"
     ],
     "WitnessSubmitAccounts": [
-    {% for account in locking_submit_accounts %}
-      "{{ account }}"
-      {%- if not loop.last -%}
-      ,
-      {% endif %}
-    {% endfor +%}
+      "{{ locking_submit_accounts | join("\",\n      \"") }}"
     ]
   },
   "IssuingChain": {
@@ -43,20 +33,10 @@
     },
     "BridgeIssue": "{{ issuing_issue }}",
     "WitnessRewardAccounts": [
-    {% for account in issuing_reward_accounts %}
-      "{{ account }}"
-      {%- if not loop.last -%}
-      ,
-      {% endif %}
-    {% endfor +%}
+      "{{ issuing_reward_accounts | join("\",\n      \"") }}"
     ],
     "WitnessSubmitAccounts": [
-    {% for account in issuing_submit_accounts %}
-      "{{ account }}"
-      {%- if not loop.last -%}
-      ,
-      {% endif %}
-    {% endfor +%}
+      "{{ issuing_submit_accounts | join("\",\n      \"") }}"
     ]
   },
   "Witnesses": {

--- a/sidechain_cli/server/config/templates/rippled.jinja
+++ b/sidechain_cli/server/config/templates/rippled.jinja
@@ -116,6 +116,6 @@ fixSTAmountCanonicalize
 fixRmSmallIncreasedQOffers
 CheckCashMakesTrustLine
 NonFungibleTokensV1
-{#- fixNFTokenDirV1 #}
-{#- ExpandedSignerList #}
+{# fixNFTokenDirV1 #}
+{# ExpandedSignerList #}
 XChainBridge

--- a/sidechain_cli/server/config/templates/witness.jinja
+++ b/sidechain_cli/server/config/templates/witness.jinja
@@ -14,11 +14,11 @@
   },
   "IssuingChain": {
     "Endpoint": {
-      {% if is_linux -%}
+      {% if is_linux %}
       "IP": "127.0.0.2",
-      {% else -%}
+      {% else %}
       "IP": "127.0.0.1",
-      {%- endif %}
+      {% endif %}
       "Port": {{ issuing_chain_port }}
     },
     "TxnSubmit": {
@@ -30,11 +30,11 @@
     "RewardAccount": "{{ issuing_reward_account }}"
   },
   "RPCEndpoint": {
-    {% if is_linux -%}
+    {% if is_linux %}
     "IP": "127.0.0.3",
-    {% else -%}
+    {% else %}
     "IP": "127.0.0.1",
-    {%- endif %}
+    {% endif %}
     "Port": {{ witness_port }}
   },
   "DBDir": "{{ db_dir }}",

--- a/sidechain_cli/utils/config_file.py
+++ b/sidechain_cli/utils/config_file.py
@@ -138,7 +138,7 @@ class BridgeConfig(ConfigItem):
 
     name: str
     chains: Tuple[str, str]
-    witnesses: List[str]
+    num_witnesses: int
     door_accounts: Tuple[str, str]
     xchain_currencies: Tuple[Currency, Currency]
     signature_reward: str

--- a/sidechain_cli/utils/types.py
+++ b/sidechain_cli/utils/types.py
@@ -1,6 +1,6 @@
 """Helper types."""
 
-from typing import List, Literal, Tuple, TypedDict, Union
+from typing import Literal, Tuple, TypedDict, Union
 
 
 class ServerData(TypedDict):
@@ -46,7 +46,7 @@ class BridgeData(TypedDict):
 
     name: str
     chains: Tuple[str, str]
-    witnesses: List[str]
+    num_witnesses: int
     door_accounts: Tuple[str, str]
     xchain_currencies: Tuple[Currency, Currency]
     signature_reward: str

--- a/tests/bridge/test_build.py
+++ b/tests/bridge/test_build.py
@@ -44,8 +44,8 @@ class TestBridgeBuild:
         with open(os.path.join(config_dir, "bridge_bootstrap.json")) as f:
             bootstrap = json.load(f)
 
-        locking_door = bootstrap["locking_chain_door"]["id"]
-        issuing_door = bootstrap["issuing_chain_door"]["id"]
+        locking_door = bootstrap["LockingChain"]["DoorAccount"]["Address"]
+        issuing_door = bootstrap["IssuingChain"]["DoorAccount"]["Address"]
         fund_result = runner.invoke(
             main, ["fund", f"--account={locking_door}", "--chain=locking_chain"]
         )

--- a/tests/bridge/test_build.py
+++ b/tests/bridge/test_build.py
@@ -71,7 +71,7 @@ class TestBridgeBuild:
         signer_list = [
             obj for obj in locking_objects if obj["LedgerEntryType"] == "SignerList"
         ][0]
-        assert len(signer_list["SignerEntries"]) == len(bridge_config.witnesses)
+        assert len(signer_list["SignerEntries"]) == bridge_config.num_witnesses
 
         issuing_objects_result = issuing_client.request(
             AccountObjects(account=issuing_door)
@@ -84,4 +84,4 @@ class TestBridgeBuild:
         signer_list = [
             obj for obj in issuing_objects if obj["LedgerEntryType"] == "SignerList"
         ][0]
-        assert len(signer_list["SignerEntries"]) == len(bridge_config.witnesses)
+        assert len(signer_list["SignerEntries"]) == bridge_config.num_witnesses

--- a/tests/bridge/test_create.py
+++ b/tests/bridge/test_create.py
@@ -45,8 +45,8 @@ class TestBridgeCreate:
             "chains": ["locking_chain", "issuing_chain"],
             "witnesses": ["witness0", "witness1", "witness2", "witness3", "witness4"],
             "door_accounts": [
-                bootstrap["locking_chain_door"]["id"],
-                bootstrap["issuing_chain_door"]["id"],
+                bootstrap["LockingChain"]["DoorAccount"]["Address"],
+                bootstrap["IssuingChain"]["DoorAccount"]["Address"],
             ],
             "xchain_currencies": ["XRP", "XRP"],
             "signature_reward": "100",

--- a/tests/bridge/test_create.py
+++ b/tests/bridge/test_create.py
@@ -43,7 +43,7 @@ class TestBridgeCreate:
         expected_result = {
             "name": "test_bridge",
             "chains": ["locking_chain", "issuing_chain"],
-            "witnesses": ["witness0", "witness1", "witness2", "witness3", "witness4"],
+            "num_witnesses": 5,
             "door_accounts": [
                 bootstrap["LockingChain"]["DoorAccount"]["Address"],
                 bootstrap["IssuingChain"]["DoorAccount"]["Address"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,7 +119,7 @@ def create_bridge(runner):
     with open(os.path.join(config_dir, "bridge_bootstrap.json")) as f:
         bootstrap = json.load(f)
 
-    locking_door = bootstrap["locking_chain_door"]["id"]
+    locking_door = bootstrap["LockingChain"]["DoorAccount"]["Address"]
     fund_result = runner.invoke(
         main, ["fund", f"--account={locking_door}", "--chain", "locking_chain", "-v"]
     )


### PR DESCRIPTION
## High Level Overview of Change

This PR switches to a new `bridge_bootstrap.json` format (see Jinja template changes for details). It also switches the bridge config from using each individual witness to using just the number of witnesses.

### Context of Change

The new bootstrap format contains more information, which is useful for setting up a production-grade bridge (where you don't have access to the witness configs).

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Test Plan

Tests pass.
