### PR TITLE
fix: add create-config to scripts

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,4 +1,5 @@
 rm ~/.config/sidechain-cli/config.json  # TODO: remove once cleanup is better
+sidechain-cli server create-config all
 sidechain-cli server start-all
 sidechain-cli server list
 sidechain-cli bridge create --name=bridge --chains locking_chain issuing_chain --witness witness0 --witness witness1 --witness witness2 --witness witness3 --witness witness4

--- a/scripts/tutorial.sh
+++ b/scripts/tutorial.sh
@@ -1,4 +1,5 @@
 rm ~/.config/sidechain-cli/config.json  # TODO: remove once cleanup is better
+sidechain-cli server create-config all
 sidechain-cli server start-all --verbose
 sidechain-cli server list
 read -p "Pausing... (hit enter to continue)"


### PR DESCRIPTION
## High Level Overview of Change

This PR creates the config files as a part of running `start.sh` and `tutorial.sh`.

### Context of Change

There's nothing that indicates you need to create the config files before running the scripts

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

N/A