### PR TITLE
refactor: set up exceptions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,11 +19,13 @@
         "envvar",
         "fout",
         "getenv",
+        "keypress",
         "legleux",
         "noqa",
         "pformat",
         "pytest",
         "secho",
+        "tablefmt",
         "witnessd",
         "xbridge",
         "xchain"

--- a/sidechain_cli/exceptions.py
+++ b/sidechain_cli/exceptions.py
@@ -1,0 +1,9 @@
+"""Sidechain CLI Exceptions."""
+
+from click import ClickException
+
+
+class SidechainCLIException(ClickException):
+    """Base sidechain CLI exception."""
+
+    pass

--- a/sidechain_cli/exceptions.py
+++ b/sidechain_cli/exceptions.py
@@ -1,5 +1,7 @@
 """Sidechain CLI Exceptions."""
 
+from __future__ import annotations
+
 from click import ClickException
 
 
@@ -7,3 +9,11 @@ class SidechainCLIException(ClickException):
     """Base sidechain CLI exception."""
 
     pass
+
+
+class AttestationTimeoutException(SidechainCLIException):
+    """Exception thrown if there is a timeout when waiting for attestations."""
+
+    def __init__(self: AttestationTimeoutException) -> None:
+        """Initialize AttestationTimeoutException."""
+        super().__init__("Timeout on attestations.")

--- a/sidechain_cli/misc/fund.py
+++ b/sidechain_cli/misc/fund.py
@@ -7,6 +7,7 @@ from xrpl.models import AccountInfo, Payment
 from xrpl.utils import xrp_to_drops
 from xrpl.wallet import Wallet
 
+from sidechain_cli.exceptions import SidechainCLIException
 from sidechain_cli.utils import get_config, submit_tx
 
 
@@ -43,10 +44,10 @@ def fund_account(chain: str, account: str, verbose: bool = False) -> None:
         verbose: Whether or not to print more verbose information.
 
     Raises:
-        ClickException: If the chain is the issuing chain.
+        SidechainCLIException: If the chain is the issuing chain.
     """  # noqa: D301
     if chain == "issuing_chain":
-        raise click.ClickException(
+        raise SidechainCLIException(
             "Cannot fund account on issuing chain. Must use `create-account`."
         )
 

--- a/sidechain_cli/server/request.py
+++ b/sidechain_cli/server/request.py
@@ -5,6 +5,7 @@ from typing import Optional, Tuple
 
 import click
 
+from sidechain_cli.exceptions import SidechainCLIException
 from sidechain_cli.utils import ChainConfig, get_config
 
 
@@ -68,8 +69,10 @@ def get_server_status(name: Optional[str] = None, query_all: bool = False) -> No
     Args:
         name: The name of the server to query.
         query_all: Whether to stop all of the servers.
+
+    Raises:
+        SidechainCLIException: If neither a name or `--all` is specified.
     """  # noqa: D301
     if name is None and query_all is False:
-        click.echo("Error: Must specify a name or `--all`.")
-        return
+        raise SidechainCLIException("Must specify a name or `--all`.")
     click.echo(f"{name} {query_all}")

--- a/sidechain_cli/server/start.py
+++ b/sidechain_cli/server/start.py
@@ -9,6 +9,7 @@ from typing import List, Optional, Tuple, cast
 
 import click
 
+from sidechain_cli.exceptions import SidechainCLIException
 from sidechain_cli.utils import (
     ChainConfig,
     ChainData,
@@ -95,6 +96,9 @@ def start_server(name: str, exe: str, config: str, verbose: bool = False) -> Non
         exe: The filepath to the executable.
         config: The filepath to the config file.
         verbose: Whether or not to print more verbose information.
+
+    Raises:
+        SidechainCLIException: If server is already running with that name/config.
     """  # noqa: D301
     exe = os.path.abspath(exe)
     config = os.path.abspath(config)
@@ -106,8 +110,7 @@ def start_server(name: str, exe: str, config: str, verbose: bool = False) -> Non
             config_json = json.load(f)
         is_rippled = False
     if check_server_exists(name, config):
-        click.echo("Error: Server already running with that name or config.")
-        return
+        raise SidechainCLIException("Server already running with that name or config.")
 
     server_type = "rippled" if is_rippled else "witness"
     if verbose:
@@ -214,10 +217,12 @@ def start_all_servers(
         rippled_only: Only start up the rippled servers.
         witness_only: Only start up the witness servers.
         verbose: Whether or not to print more verbose information.
+
+    Raises:
+        SidechainCLIException: If `config_dir` is not a directory.
     """  # noqa: D301
     if not os.path.isdir(config_dir):
-        click.echo(f"Error: {config_dir} is not a directory.")
-        return
+        raise SidechainCLIException(f"{config_dir} is not a directory.")
     if not rippled_only and not witness_only:
         all_chains = True
     else:
@@ -340,10 +345,12 @@ def stop_server(
         name: The name of the server to stop.
         stop_all: Whether to stop all of the servers.
         verbose: Whether or not to print more verbose information.
+
+    Raises:
+        SidechainCLIException: If neither a name or `--all` is specified.
     """  # noqa: D301
     if name is None and stop_all is False:
-        click.echo("Error: Must specify a name or `--all`.")
-        return
+        raise SidechainCLIException("Must specify a name or `--all`.")
     config = get_config()
     if stop_all:
         servers = cast(List[ServerConfig], config.witnesses) + cast(
@@ -419,10 +426,12 @@ def restart_server(
         name: The name of the server to restart.
         restart_all: Whether to restart all of the servers.
         verbose: Whether or not to print more verbose information.
+
+    Raises:
+        SidechainCLIException: If neither a name or `--all` is specified.
     """  # noqa: D301
     if name is None and restart_all is False:
-        click.echo("Error: Must specify a name or `--all`.")
-        return
+        raise SidechainCLIException("Must specify a name or `--all`.")
 
     config = get_config()
     if restart_all:

--- a/sidechain_cli/server/start.py
+++ b/sidechain_cli/server/start.py
@@ -54,7 +54,7 @@ def _run_process(to_run: List[str], out_file: str) -> Tuple[int, str]:
     if process.poll() is not None:
         with open(output_file) as f:
             click.echo(f.read())
-        raise click.ClickException("Process did not start up correctly.")
+        raise SidechainCLIException("Process did not start up correctly.")
 
     return process.pid, output_file
 

--- a/sidechain_cli/utils/config_file.py
+++ b/sidechain_cli/utils/config_file.py
@@ -244,12 +244,12 @@ class ConfigFile:
             The ChainConfig object corresponding to that chain.
 
         Raises:
-            Exception: if there is no chain with that name.
+            SidechainCLIException: if there is no chain with that name.
         """
         for chain in self.chains:
             if chain.name == name:
                 return chain
-        raise Exception(f"No chain with name {name}.")
+        raise SidechainCLIException(f"No chain with name {name}.")
 
     def get_witness(self: ConfigFile, name: str) -> WitnessConfig:
         """
@@ -280,7 +280,7 @@ class ConfigFile:
             The ServerConfig object corresponding to that server.
 
         Raises:
-            Exception: if there is no server with that name.
+            SidechainCLIException: if there is no server with that name.
         """
         for chain in self.chains:
             if chain.name == name:
@@ -288,7 +288,7 @@ class ConfigFile:
         for witness in self.witnesses:
             if witness.name == name:
                 return witness
-        raise Exception(f"No server with name {name}.")
+        raise SidechainCLIException(f"No server with name {name}.")
 
     def get_bridge(self: ConfigFile, name: str) -> BridgeConfig:
         """
@@ -301,12 +301,12 @@ class ConfigFile:
             The BridgeConfig object corresponding to that bridge.
 
         Raises:
-            Exception: if there is no bridge with that name.
+            SidechainCLIException: if there is no bridge with that name.
         """
         for bridge in self.bridges:
             if bridge.name == name:
                 return bridge
-        raise Exception(f"No bridge with name {name}.")
+        raise SidechainCLIException(f"No bridge with name {name}.")
 
     def to_dict(self: ConfigFile) -> Dict[str, List[Dict[str, Any]]]:
         """

--- a/sidechain_cli/utils/config_file.py
+++ b/sidechain_cli/utils/config_file.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Literal, Tuple, Type, TypeVar, Union, cast
 from xrpl.clients import JsonRpcClient
 from xrpl.models import IssuedCurrency, XChainBridge
 
+from sidechain_cli.exceptions import SidechainCLIException
 from sidechain_cli.utils.rippled_config import RippledConfig
 from sidechain_cli.utils.types import Currency
 
@@ -261,12 +262,12 @@ class ConfigFile:
             The WitnessConfig object corresponding to that witness.
 
         Raises:
-            Exception: if there is no witness with that name.
+            SidechainCLIException: if there is no witness with that name.
         """
         for witness in self.witnesses:
             if witness.name == name:
                 return witness
-        raise Exception(f"No witness with name {name}.")
+        raise SidechainCLIException(f"No witness with name {name}.")
 
     def get_server(self: ConfigFile, name: str) -> ServerConfig:
         """

--- a/sidechain_cli/utils/config_utils.py
+++ b/sidechain_cli/utils/config_utils.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Dict, Optional, cast
 
+from sidechain_cli.exceptions import SidechainCLIException
 from sidechain_cli.utils.config_file import (
     BridgeConfig,
     ChainConfig,
@@ -115,10 +116,10 @@ def remove_chain(name: Optional[str] = None, remove_all: bool = False) -> None:
         remove_all: Whether to remove all of the chains.
 
     Raises:
-        Exception: If `name` is `None` and `remove_all` is `False`.
+        SidechainCLIException: If `name` is `None` and `remove_all` is `False`.
     """
     if name is None and remove_all is False:
-        raise Exception(
+        raise SidechainCLIException(
             "Cannot remove chain if name is `None` and remove_all is `False`."
         )
     conf = get_config()
@@ -150,10 +151,10 @@ def remove_witness(name: Optional[str] = None, remove_all: bool = False) -> None
         remove_all: Whether to remove all of the witnesses.
 
     Raises:
-        Exception: If `name` is `None` and `remove_all` is `False`.
+        SidechainCLIException: If `name` is `None` and `remove_all` is `False`.
     """
     if name is None and remove_all is False:
-        raise Exception(
+        raise SidechainCLIException(
             "Cannot remove witness if name is `None` and remove_all is `False`."
         )
     conf = get_config()
@@ -173,10 +174,10 @@ def remove_server(name: Optional[str] = None, remove_all: bool = False) -> None:
         remove_all: Whether to remove all of the servers.
 
     Raises:
-        Exception: If `name` is `None` and `remove_all` is `False`.
+        SidechainCLIException: If `name` is `None` and `remove_all` is `False`.
     """
     if name is None and remove_all is False:
-        raise Exception(
+        raise SidechainCLIException(
             "Cannot remove server if name is `None` and remove_all is `False`."
         )
     conf = get_config()
@@ -216,10 +217,10 @@ def remove_bridge(name: Optional[str] = None, remove_all: bool = False) -> None:
         remove_all: Whether to remove all of the bridges.
 
     Raises:
-        Exception: If `name` is `None` and `remove_all` is `False`.
+        SidechainCLIException: If `name` is `None` and `remove_all` is `False`.
     """
     if name is None and remove_all is False:
-        raise Exception(
+        raise SidechainCLIException(
             "Cannot remove bridge if name is `None` and remove_all is `False`."
         )
     conf = get_config()

--- a/tests/misc/test_explorer.py
+++ b/tests/misc/test_explorer.py
@@ -10,7 +10,8 @@ class TestExplorer:
     def test_explorer(self):
         runner = CliRunner()
         with unittest.mock.patch("webbrowser.open") as mock_open:
-            runner.invoke(main, "explorer")
+            explorer_result = runner.invoke(main, "explorer")
+            assert explorer_result.exit_code == 0, explorer_result.output
             expected_path = os.path.abspath(
                 os.path.join(
                     os.path.realpath(__file__),
@@ -22,4 +23,5 @@ class TestExplorer:
                     "explorer.html",
                 )
             )
+
             assert mock_open.call_args[0][0] == f"file://{expected_path}"

--- a/tests/misc/test_fund.py
+++ b/tests/misc/test_fund.py
@@ -1,5 +1,6 @@
 import pytest
 from xrpl.models import AccountInfo
+from xrpl.wallet import Wallet
 
 from sidechain_cli.main import main
 from sidechain_cli.utils import get_config
@@ -10,7 +11,7 @@ class TestFund:
     def test_fund(self, runner):
         client = get_config().get_chain("locking_chain").get_client()
 
-        test_account = "rHvgvEAy1npZ2kCde6mM5anjXo7Gpqxi78"
+        test_account = Wallet.create().classic_address
         initial_account_info = client.request(AccountInfo(account=test_account))
         assert initial_account_info.status.value == "error"
         assert initial_account_info.result["error"] == "actNotFound"


### PR DESCRIPTION
## High Level Overview of Change

This PR adds native exceptions (inherited from `click.ClickException`) for the package and replaces existing errors. This means that exceptions are actually thrown, but it doesn't print out a messy stack-trace in the UI.

### Context of Change

Neater to work with

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Test Plan

Tests still pass.
