### PR TITLE
fix: make sure servers are properly up before continuing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
         "envvar",
         "fout",
         "getenv",
+        "httpx",
         "keypress",
         "legleux",
         "noqa",

--- a/sidechain_cli/server/start.py
+++ b/sidechain_cli/server/start.py
@@ -157,16 +157,17 @@ def start_server(
         to_run = [exe, "--config", config, "--verbose"]
 
     process, output_file = _run_process(to_run, name)
-    # check if server actually started up correctly
-    _wait_for_process(
-        process,
-        config_object.port_rpc_admin_local.ip,
-        int(config_object.port_rpc_admin_local.port),
-        output_file,
-        is_rippled,
-    )
 
     if is_rippled:
+        # check if server actually started up correctly
+        _wait_for_process(
+            process,
+            config_object.port_rpc_admin_local.ip,
+            int(config_object.port_rpc_admin_local.port),
+            output_file,
+            True,
+        )
+
         chain_data: ChainData = {
             "name": name,
             "type": "rippled",
@@ -181,6 +182,14 @@ def start_server(
         # add chain to config file
         add_chain(chain_data)
     else:
+        # check if server actually started up correctly
+        _wait_for_process(
+            process,
+            config_json["RPCEndpoint"]["IP"],
+            config_json["RPCEndpoint"]["Port"],
+            output_file,
+            False,
+        )
         witness_data: WitnessData = {
             "name": name,
             "type": "witness",

--- a/sidechain_cli/server/start.py
+++ b/sidechain_cli/server/start.py
@@ -157,17 +157,16 @@ def start_server(
         to_run = [exe, "--config", config, "--verbose"]
 
     process, output_file = _run_process(to_run, name)
+    # check if server actually started up correctly
+    _wait_for_process(
+        process,
+        config_object.port_rpc_admin_local.ip,
+        int(config_object.port_rpc_admin_local.port),
+        output_file,
+        is_rippled,
+    )
 
     if is_rippled:
-        # check if server actually started up correctly
-        _wait_for_process(
-            process,
-            config_object.port_rpc_admin_local.ip,
-            int(config_object.port_rpc_admin_local.port),
-            output_file,
-            True,
-        )
-
         chain_data: ChainData = {
             "name": name,
             "type": "rippled",
@@ -182,14 +181,6 @@ def start_server(
         # add chain to config file
         add_chain(chain_data)
     else:
-        # check if server actually started up correctly
-        _wait_for_process(
-            process,
-            config_json["RPCEndpoint"]["IP"],
-            config_json["RPCEndpoint"]["Port"],
-            output_file,
-            False,
-        )
         witness_data: WitnessData = {
             "name": name,
             "type": "witness",

--- a/sidechain_cli/server/start.py
+++ b/sidechain_cli/server/start.py
@@ -11,8 +11,6 @@ from typing import List, Optional, Tuple, cast
 
 import click
 import httpx
-from xrpl.clients import JsonRpcClient
-from xrpl.models import ServerInfo
 
 from sidechain_cli.exceptions import SidechainCLIException
 from sidechain_cli.utils import (
@@ -49,17 +47,13 @@ def _wait_for_process(
     http_ip: str,
     http_port: int,
     output_file: str,
-    is_rippled: bool,
 ) -> None:
     http_url = f"http://{http_ip}:{http_port}"
     time_waited = 0.0
     while time_waited < _START_UP_TIME:
         try:
-            if is_rippled:
-                JsonRpcClient(http_url).request(ServerInfo())
-            else:
-                request = {"method": "server_info"}
-                httpx.post(http_url, json=request)
+            request = {"method": "server_info"}
+            httpx.post(http_url, json=request)
             return
         except (httpx.ConnectError, httpx.RemoteProtocolError):
             time.sleep(_WAIT_INCREMENT)
@@ -165,7 +159,6 @@ def start_server(
             config_object.port_rpc_admin_local.ip,
             int(config_object.port_rpc_admin_local.port),
             output_file,
-            True,
         )
 
         chain_data: ChainData = {
@@ -188,7 +181,6 @@ def start_server(
             config_json["RPCEndpoint"]["IP"],
             config_json["RPCEndpoint"]["Port"],
             output_file,
-            False,
         )
         witness_data: WitnessData = {
             "name": name,
@@ -318,7 +310,6 @@ def start_all_servers(
                     config_object.port_rpc_admin_local.ip,
                     int(config_object.port_rpc_admin_local.port),
                     output_file,
-                    True,
                 )
                 chain_data: ChainData = {
                     "name": name,
@@ -366,7 +357,6 @@ def start_all_servers(
                     config_json["RPCEndpoint"]["IP"],
                     config_json["RPCEndpoint"]["Port"],
                     output_file,
-                    False,
                 )
 
                 witness_data: WitnessData = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,9 @@ def pytest_configure(config):
     before performing collection and entering the run test loop.
     """
     global home_dir, config_dir, mocked_vars
+    runner = CliRunner()
+    runner.invoke(main, ["server", "stop", "--all"])
+
     config_dir = tempfile.TemporaryDirectory()
     env_vars = unittest.mock.patch.dict(
         os.environ,


### PR DESCRIPTION
## High Level Overview of Change

This PR makes sure that all the servers (rippled and witness, docker and local) respond to `server_info` requests before the "start" command returns. There are also some minor refactors of Docker code (which makes the code neater and makes it much faster to stop servers running in Docker).

### Context of Change

There were often errors thrown because of timing issues, when the servers were technically started but hadn't fully started up (which meant they weren't responding to requests).

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Tests pass locally. All scripts work.
