### PR TITLE
feat: allow funding of multiple accounts, submit multiple txs in one ledger

### DIFF
--- a/scripts/docker-start.sh
+++ b/scripts/docker-start.sh
@@ -3,12 +3,12 @@ sidechain-cli server create-config all --docker
 sidechain-cli server start-all --rippled-only --docker
 sidechain-cli server list
 sidechain-cli explorer
-jq .LockingChain.DoorAccount.Address $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs sidechain-cli fund --chain locking_chain --account
-jq '.LockingChain.WitnessSubmitAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs -L1 sidechain-cli fund --chain locking_chain --account
-jq '.LockingChain.WitnessRewardAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs -L1 sidechain-cli fund --chain locking_chain --account
+jq .LockingChain.DoorAccount.Address $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs sidechain-cli fund locking_chain
+jq '.LockingChain.WitnessSubmitAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs sidechain-cli fund locking_chain
+jq '.LockingChain.WitnessRewardAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs sidechain-cli fund locking_chain
 sidechain-cli bridge build --name=bridge -v
 sidechain-cli server start-all --witness-only --docker
 sidechain-cli server list
-sidechain-cli fund --chain locking_chain --account raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym
+sidechain-cli fund locking_chain raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym
 sidechain-cli bridge create-account --from_locking --bridge bridge --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi --amount 10 -v
 sidechain-cli bridge transfer --bridge bridge --from_locking --amount 10000000 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM --verbose

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -3,12 +3,12 @@ sidechain-cli server create-config all
 sidechain-cli server start-all --rippled-only
 sidechain-cli server list
 sidechain-cli explorer
-jq .LockingChain.DoorAccount.Address $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs sidechain-cli fund --chain locking_chain --account
-jq '.LockingChain.WitnessSubmitAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs -L1 sidechain-cli fund --chain locking_chain --account
-jq '.LockingChain.WitnessRewardAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs -L1 sidechain-cli fund --chain locking_chain --account
+jq .LockingChain.DoorAccount.Address $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs sidechain-cli fund locking_chain
+jq '.LockingChain.WitnessSubmitAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs sidechain-cli fund locking_chain
+jq '.LockingChain.WitnessRewardAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs sidechain-cli fund locking_chain
 sidechain-cli bridge build --name=bridge -v
 sidechain-cli server start-all --witness-only
 sidechain-cli server list
-sidechain-cli fund --chain locking_chain --account raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym
+sidechain-cli fund locking_chain raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym
 sidechain-cli bridge create-account --from_locking --bridge bridge --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi --amount 10 -v
 sidechain-cli bridge transfer --bridge bridge --from_locking --amount 10000000 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM --verbose

--- a/scripts/tutorial.sh
+++ b/scripts/tutorial.sh
@@ -4,12 +4,12 @@ sidechain-cli server start-all --rippled-only --verbose
 sidechain-cli server list
 read -p "Pausing... (hit enter to continue)"
 sidechain-cli explorer
-jq .LockingChain.DoorAccount.Address $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs sidechain-cli fund --chain locking_chain --account
-jq '.LockingChain.WitnessSubmitAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs -L1 sidechain-cli fund --chain locking_chain --account
-jq '.LockingChain.WitnessRewardAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs -L1 sidechain-cli fund --chain locking_chain --account
+jq .LockingChain.DoorAccount.Address $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs sidechain-cli fund locking_chain
+jq '.LockingChain.WitnessSubmitAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs sidechain-cli fund locking_chain
+jq '.LockingChain.WitnessRewardAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs sidechain-cli fund locking_chain
 sidechain-cli bridge build --name=bridge -v
 sidechain-cli server start-all --witness-only --verbose
 sidechain-cli server list
-sidechain-cli fund --chain locking_chain --account raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym
+sidechain-cli fund locking_chain raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym
 sidechain-cli bridge create-account --from_locking --bridge bridge --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi --amount 10 -v
 sidechain-cli bridge transfer --bridge bridge --from_locking --amount 10000000 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM --tutorial

--- a/sidechain_cli/bridge/transfer.py
+++ b/sidechain_cli/bridge/transfer.py
@@ -21,7 +21,7 @@ def _submit_tx(
     verbose: int,
     close_ledgers: bool,
 ) -> Response:
-    result = submit_tx(tx, client, secret, verbose, close_ledgers)
+    result = submit_tx(tx, client, secret, verbose, close_ledgers)[0]
     tx_result = (
         result.result.get("error")
         or result.result.get("engine_result")

--- a/sidechain_cli/misc/fund.py
+++ b/sidechain_cli/misc/fund.py
@@ -16,14 +16,12 @@ from sidechain_cli.utils import get_config, submit_tx
 @click.argument(
     "chain",
     required=True,
-    prompt=True,
     type=str,
     help="The chain to fund an account on.",
 )
 @click.argument(
     "accounts",
     required=True,
-    prompt=True,
     type=str,
     nargs=-1,
     help="The account(s) to fund.",
@@ -34,7 +32,7 @@ from sidechain_cli.utils import get_config, submit_tx
     is_flag=True,
     help="Whether or not to print more verbose information.",
 )
-def fund_account(chain: str, accounts: str, verbose: bool = False) -> None:
+def fund_account(chain: str, accounts: List[str], verbose: bool = False) -> None:
     """
     Of the form `sidechain-cli fund CHAIN ACCOUNT1 [ACCOUNT2 ...].
 

--- a/sidechain_cli/misc/fund.py
+++ b/sidechain_cli/misc/fund.py
@@ -60,9 +60,13 @@ def fund_account(chain: str, accounts: str, verbose: bool = False) -> None:
     wallet = Wallet("snoPBrXtMeMyMHUVTgbuqAfg1SUTb", 0)
     payments = []
     for account in accounts:
-        payments.append(Payment(
-            account=wallet.classic_address, destination=account, amount=xrp_to_drops(1000)
-        ))
+        payments.append(
+            Payment(
+                account=wallet.classic_address,
+                destination=account,
+                amount=xrp_to_drops(1000),
+            )
+        )
     submit_tx(payments, client, wallet.seed)
     if verbose:
         for account in accounts:

--- a/sidechain_cli/misc/fund.py
+++ b/sidechain_cli/misc/fund.py
@@ -17,14 +17,12 @@ from sidechain_cli.utils import get_config, submit_tx
     "chain",
     required=True,
     type=str,
-    help="The chain to fund an account on.",
 )
 @click.argument(
     "accounts",
     required=True,
     type=str,
     nargs=-1,
-    help="The account(s) to fund.",
 )
 @click.option(
     "-v",

--- a/sidechain_cli/misc/fund.py
+++ b/sidechain_cli/misc/fund.py
@@ -12,19 +12,20 @@ from sidechain_cli.utils import get_config, submit_tx
 
 
 @click.command(name="fund")
-@click.option(
-    "--chain",
+@click.argument(
+    "chain",
     required=True,
     prompt=True,
     type=str,
     help="The chain to fund an account on.",
 )
-@click.option(
-    "--account",
+@click.argument(
+    "accounts",
     required=True,
     prompt=True,
     type=str,
-    help="The account to fund.",
+    nargs=-1,
+    help="The account(s) to fund.",
 )
 @click.option(
     "-v",
@@ -32,15 +33,17 @@ from sidechain_cli.utils import get_config, submit_tx
     is_flag=True,
     help="Whether or not to print more verbose information.",
 )
-def fund_account(chain: str, account: str, verbose: bool = False) -> None:
+def fund_account(chain: str, accounts: str, verbose: bool = False) -> None:
     """
+    Of the form `sidechain-cli fund CHAIN ACCOUNT1 [ACCOUNT2 ...].
+
     Fund an account from the genesis account. Only works on a normal standalone rippled
     node.
     \f
 
     Args:
         chain: The chain to fund an account on.
-        account: The chain to fund an account on.
+        accounts: The account(s) to fund.
         verbose: Whether or not to print more verbose information.
 
     Raises:
@@ -55,9 +58,12 @@ def fund_account(chain: str, account: str, verbose: bool = False) -> None:
     client = chain_config.get_client()
 
     wallet = Wallet("snoPBrXtMeMyMHUVTgbuqAfg1SUTb", 0)
-    payment = Payment(
-        account=wallet.classic_address, destination=account, amount=xrp_to_drops(1000)
-    )
-    submit_tx(payment, client, wallet.seed)
+    payments = []
+    for account in accounts:
+        payments.append(Payment(
+            account=wallet.classic_address, destination=account, amount=xrp_to_drops(1000)
+        ))
+    submit_tx(payments, client, wallet.seed)
     if verbose:
-        click.echo(pformat(client.request(AccountInfo(account=account)).result))
+        for account in accounts:
+            click.echo(pformat(client.request(AccountInfo(account=account)).result))

--- a/sidechain_cli/misc/fund.py
+++ b/sidechain_cli/misc/fund.py
@@ -1,9 +1,10 @@
 """Fund an account from the genesis account."""
 
 from pprint import pformat
+from typing import List
 
 import click
-from xrpl.models import AccountInfo, Payment
+from xrpl.models import AccountInfo, Payment, Transaction
 from xrpl.utils import xrp_to_drops
 from xrpl.wallet import Wallet
 
@@ -58,7 +59,7 @@ def fund_account(chain: str, accounts: str, verbose: bool = False) -> None:
     client = chain_config.get_client()
 
     wallet = Wallet("snoPBrXtMeMyMHUVTgbuqAfg1SUTb", 0)
-    payments = []
+    payments: List[Transaction] = []
     for account in accounts:
         payments.append(
             Payment(

--- a/sidechain_cli/utils/attestations.py
+++ b/sidechain_cli/utils/attestations.py
@@ -13,7 +13,7 @@ from sidechain_cli.exceptions import AttestationTimeoutException, SidechainCLIEx
 from sidechain_cli.utils.config_file import BridgeConfig
 
 _ATTESTATION_TIME_LIMIT = 10  # in seconds
-_WAIT_STEP_LENGTH = 0.05
+_WAIT_STEP_LENGTH = 1
 
 _EXTERNAL_ATTESTATION_TIME_LIMIT = 20
 _EXTERNAL_WAIT_STEP_LENGTH = 1

--- a/sidechain_cli/utils/transaction.py
+++ b/sidechain_cli/utils/transaction.py
@@ -64,7 +64,9 @@ def submit_tx(
             results.append(result)
             tx_results.append(result.result["meta"]["TransactionResult"])
 
-    for tx_result in tx_results:
+    for i in range(len(results)):
+        result = results[i]
+        tx_result = tx_results[i]
         if verbose > 0:
             text_color = "bright_green" if tx_result == "tesSUCCESS" else "bright_red"
             click.secho(f"Result: {tx_result}", fg=text_color)

--- a/sidechain_cli/utils/transaction.py
+++ b/sidechain_cli/utils/transaction.py
@@ -38,10 +38,8 @@ def submit_tx(
     if isinstance(txs, Transaction):
         txs = [txs]
     if verbose > 0:
-        tx_types = ', '.join([tx.transaction_type.value for tx in txs])
-        click.secho(
-            f"Submitting {tx_types} tx to {client.url}...", fg="blue"
-        )
+        tx_types = ", ".join([tx.transaction_type.value for tx in txs])
+        click.secho(f"Submitting {tx_types} tx to {client.url}...", fg="blue")
         if verbose > 1:
             for tx in txs:
                 click.echo(pformat(tx.to_xrpl()))
@@ -52,7 +50,10 @@ def submit_tx(
             signed_tx = safe_sign_and_autofill_transaction(tx, Wallet(seed, 0), client)
             results.append(submit_transaction(signed_tx, client))
         client.request(GenericRequest(method="ledger_accept"))
-        tx_results = [result.result.get("error") or result.result.get("engine_result") for result in results]
+        tx_results = [
+            result.result.get("error") or result.result.get("engine_result")
+            for result in results
+        ]
     else:
         # TODO: improve runtime when there is a batch send_reliable_submission
         results = []

--- a/sidechain_cli/utils/transaction.py
+++ b/sidechain_cli/utils/transaction.py
@@ -1,6 +1,7 @@
 """Utils related to transactions."""
 
 from pprint import pformat
+from typing import List, Union
 
 import click
 from xrpl.clients.sync_client import SyncClient
@@ -14,17 +15,17 @@ from xrpl.wallet import Wallet
 
 
 def submit_tx(
-    tx: Transaction,
+    txs: Union[Transaction, List[Transaction]],
     client: SyncClient,
     seed: str,
     verbose: int = 0,
     close_ledgers: bool = True,
-) -> Response:
+) -> List[Response]:
     """
     Submit a transaction to rippled, asking rippled to sign it as well.
 
     Args:
-        tx: The transaction to submit.
+        txs: The transaction(s) to submit.
         client: The client to submit it with.
         seed: The seed to sign the transaction with.
         verbose: Whether or not to print more verbose information.
@@ -34,26 +35,38 @@ def submit_tx(
     Returns:
         The response from rippled.
     """
+    if isinstance(txs, Transaction):
+        txs = [txs]
     if verbose > 0:
+        tx_types = ', '.join([tx.transaction_type.value for tx in txs])
         click.secho(
-            f"Submitting {tx.transaction_type.value} tx to {client.url}...", fg="blue"
+            f"Submitting {tx_types} tx to {client.url}...", fg="blue"
         )
         if verbose > 1:
-            click.echo(pformat(tx.to_xrpl()))
+            for tx in txs:
+                click.echo(pformat(tx.to_xrpl()))
 
     if close_ledgers:
-        signed_tx = safe_sign_and_autofill_transaction(tx, Wallet(seed, 0), client)
-        result = submit_transaction(signed_tx, client)
+        results = []
+        for tx in txs:
+            signed_tx = safe_sign_and_autofill_transaction(tx, Wallet(seed, 0), client)
+            results.append(submit_transaction(signed_tx, client))
         client.request(GenericRequest(method="ledger_accept"))
-        tx_result = result.result.get("error") or result.result.get("engine_result")
+        tx_results = [result.result.get("error") or result.result.get("engine_result") for result in results]
     else:
-        signed_tx = safe_sign_and_autofill_transaction(tx, Wallet(seed, 0), client)
-        result = send_reliable_submission(signed_tx, client)
-        tx_result = result.result["meta"]["TransactionResult"]
+        # TODO: improve runtime when there is a batch send_reliable_submission
+        results = []
+        tx_results = []
+        for tx in txs:
+            signed_tx = safe_sign_and_autofill_transaction(tx, Wallet(seed, 0), client)
+            result = send_reliable_submission(signed_tx, client)
+            results.append(result)
+            tx_results.append(result.result["meta"]["TransactionResult"])
 
-    if verbose > 0:
-        text_color = "bright_green" if tx_result == "tesSUCCESS" else "bright_red"
-        click.secho(f"Result: {tx_result}", fg=text_color)
-    if verbose > 1:
-        click.echo(pformat(result.result))
-    return result
+    for tx_result in tx_results:
+        if verbose > 0:
+            text_color = "bright_green" if tx_result == "tesSUCCESS" else "bright_red"
+            click.secho(f"Result: {tx_result}", fg=text_color)
+        if verbose > 1:
+            click.echo(pformat(result.result))
+    return results

--- a/tests/bridge/test_build.py
+++ b/tests/bridge/test_build.py
@@ -104,11 +104,10 @@ class TestBridgeBuild:
             + bootstrap["LockingChain"]["WitnessRewardAccounts"]
             + bootstrap["LockingChain"]["WitnessSubmitAccounts"]
         )
-        for account in accounts_locking_fund:
-            fund_result = runner.invoke(
-                main, ["fund", f"--account={account}", "--chain=locking_chain"]
-            )
-            assert fund_result.exit_code == 0, fund_result.output
+        fund_result = runner.invoke(
+            main, ["fund", "locking_chain", *accounts_locking_fund]
+        )
+        assert fund_result.exit_code == 0, fund_result.output
 
         close_ledgers()
         thread = SetInterval(close_ledgers, 1)

--- a/tests/bridge/test_create_account.py
+++ b/tests/bridge/test_create_account.py
@@ -79,8 +79,8 @@ class TestCreateAccount:
             main,
             [
                 "fund",
-                f"--account={send_wallet.classic_address}",
-                "--chain=locking_chain",
+                "locking_chain",
+                send_wallet.classic_address,
             ],
         )
         assert fund_result1.exit_code == 0, fund_result1.output

--- a/tests/bridge/test_create_account.py
+++ b/tests/bridge/test_create_account.py
@@ -22,8 +22,8 @@ class TestCreateAccount:
             main,
             [
                 "fund",
-                f"--account={send_wallet.classic_address}",
-                "--chain=locking_chain",
+                "locking_chain",
+                send_wallet.classic_address,
             ],
         )
         assert fund_result1.exit_code == 0, fund_result1.output

--- a/tests/bridge/test_transfer.py
+++ b/tests/bridge/test_transfer.py
@@ -94,8 +94,8 @@ class TestBridgeTransfer:
             main,
             [
                 "fund",
-                f"--account={send_wallet.classic_address}",
-                "--chain=locking_chain",
+                "locking_chain",
+                send_wallet.classic_address,
             ],
         )
         assert fund_result1.exit_code == 0, fund_result1.output

--- a/tests/bridge/test_transfer.py
+++ b/tests/bridge/test_transfer.py
@@ -24,8 +24,8 @@ class TestBridgeTransfer:
             main,
             [
                 "fund",
-                f"--account={send_wallet.classic_address}",
-                "--chain=locking_chain",
+                "locking_chain",
+                send_wallet.classic_address,
             ],
         )
         assert fund_result1.exit_code == 0, fund_result1.output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,11 +140,10 @@ def create_bridge():
         + bootstrap["LockingChain"]["WitnessRewardAccounts"]
         + bootstrap["LockingChain"]["WitnessSubmitAccounts"]
     )
-    for account in accounts_locking_fund:
-        fund_result = cli_runner.invoke(
-            main, ["fund", f"--account={account}", "--chain=locking_chain"]
-        )
-        assert fund_result.exit_code == 0, fund_result.output
+    fund_result = cli_runner.invoke(
+        main, ["fund", "locking_chain", *accounts_locking_fund]
+    )
+    assert fund_result.exit_code == 0, fund_result.output
 
     # build bridge
     build_result = cli_runner.invoke(
@@ -205,11 +204,10 @@ def bridge_build_setup():
         + bootstrap["LockingChain"]["WitnessRewardAccounts"]
         + bootstrap["LockingChain"]["WitnessSubmitAccounts"]
     )
-    for account in accounts_locking_fund:
-        fund_result = cli_runner.invoke(
-            main, ["fund", f"--account={account}", "--chain=locking_chain"]
-        )
-        assert fund_result.exit_code == 0, fund_result.output
+    fund_result = cli_runner.invoke(
+        main, ["fund", "locking_chain", *accounts_locking_fund]
+    )
+    assert fund_result.exit_code == 0, fund_result.output
 
     yield
 

--- a/tests/misc/test_fund.py
+++ b/tests/misc/test_fund.py
@@ -22,3 +22,20 @@ class TestFund:
         final_account_info = client.request(AccountInfo(account=test_account))
         assert final_account_info.status.value == "success"
         assert final_account_info.result["account_data"]["Account"] == test_account
+
+    def test_fund_multiple_accounts(self, runner):
+        client = get_config().get_chain("locking_chain").get_client()
+
+        test_accounts = [Wallet.create().classic_address for _ in range(4)]
+        for account in test_accounts:
+            initial_account_info = client.request(AccountInfo(account=account))
+            assert initial_account_info.status.value == "error"
+            assert initial_account_info.result["error"] == "actNotFound"
+
+        fund_result = runner.invoke(main, ["fund", "locking_chain", *test_accounts])
+        assert fund_result.exit_code == 0, fund_result.output
+
+        for account in test_accounts:
+            final_account_info = client.request(AccountInfo(account=account))
+            assert final_account_info.status.value == "success"
+            assert final_account_info.result["account_data"]["Account"] == account

--- a/tests/misc/test_fund.py
+++ b/tests/misc/test_fund.py
@@ -16,9 +16,7 @@ class TestFund:
         assert initial_account_info.status.value == "error"
         assert initial_account_info.result["error"] == "actNotFound"
 
-        fund_result = runner.invoke(
-            main, ["fund", f"--account={test_account}", "--chain=locking_chain"]
-        )
+        fund_result = runner.invoke(main, ["fund", "locking_chain", test_account])
         assert fund_result.exit_code == 0, fund_result.output
 
         final_account_info = client.request(AccountInfo(account=test_account))


### PR DESCRIPTION
## High Level Overview of Change

This PR reworks `fund` so that it can fund multiple accounts. This has the side benefit of allowing the ability to submit multiple transactions in one ledger (the code didn't allow that previously).

There isn't really any benefit right now for external networks.

### Context of Change

This speeds up the funding of accounts, since they can all happen in one ledger, instead of independent ledgers.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Test Plan

Works locally. CI passes.
