### PR TITLE
refactor: split up CLI config classes into separate files

### DIFF
--- a/sidechain_cli/utils/config_file/__init__.py
+++ b/sidechain_cli/utils/config_file/__init__.py
@@ -1,0 +1,16 @@
+"""Util methods for the sidechain CLI."""
+
+from sidechain_cli.utils.config_file.bridge_config import BridgeConfig
+from sidechain_cli.utils.config_file.chain_config import ChainConfig
+from sidechain_cli.utils.config_file.config_file import ConfigFile, get_config_folder
+from sidechain_cli.utils.config_file.server_config import ServerConfig
+from sidechain_cli.utils.config_file.witness_config import WitnessConfig
+
+__all__ = [
+    "BridgeConfig",
+    "ChainConfig",
+    "WitnessConfig",
+    "ServerConfig",
+    "ConfigFile",
+    "get_config_folder",
+]

--- a/sidechain_cli/utils/config_file/bridge_config.py
+++ b/sidechain_cli/utils/config_file/bridge_config.py
@@ -1,0 +1,76 @@
+"""Bridge information stored in the CLI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Literal, Tuple, Union, cast
+
+from xrpl.clients import JsonRpcClient
+from xrpl.models import IssuedCurrency, XChainBridge
+
+from sidechain_cli.utils.config_file.config_item import ConfigItem
+from sidechain_cli.utils.types import Currency
+
+
+def _to_issued_currency(
+    xchain_currency: Union[Literal["XRP"], Currency]
+) -> Union[Literal["XRP"], IssuedCurrency]:
+    return (
+        cast(Literal["XRP"], "XRP")
+        if xchain_currency == "XRP"
+        else IssuedCurrency.from_dict(cast(Dict[str, Any], xchain_currency))
+    )
+
+
+@dataclass
+class BridgeConfig(ConfigItem):
+    """Object representing the config for a bridge."""
+
+    name: str
+    chains: Tuple[str, str]
+    num_witnesses: int
+    door_accounts: Tuple[str, str]
+    xchain_currencies: Tuple[Currency, Currency]
+    signature_reward: str
+    create_account_amounts: Tuple[str, str]
+
+    def get_clients(self: BridgeConfig) -> Tuple[JsonRpcClient, JsonRpcClient]:
+        """
+        Get the clients for the chains associated with the bridge.
+
+        Returns:
+            The clients for the chains associated with the bridge.
+        """
+        return (JsonRpcClient(self.chains[0]), JsonRpcClient(self.chains[1]))
+
+    def get_bridge(self: BridgeConfig) -> XChainBridge:
+        """
+        Get the XChainBridge object associated with the bridge.
+
+        Returns:
+            The XChainBridge object.
+        """
+        locking_chain_issue = _to_issued_currency(self.xchain_currencies[0])
+        issuing_chain_issue = _to_issued_currency(self.xchain_currencies[1])
+        return XChainBridge(
+            locking_chain_door=self.door_accounts[0],
+            locking_chain_issue=locking_chain_issue,
+            issuing_chain_door=self.door_accounts[1],
+            issuing_chain_issue=issuing_chain_issue,
+        )
+
+    def to_xrpl(self: BridgeConfig) -> Dict[str, Any]:
+        """
+        Get the XRPL-formatted dictionary for the XChainBridge object.
+
+        Returns:
+            The XRPL-formatted dictionary for the XChainBridge object.
+        """
+        locking_chain_issue = _to_issued_currency(self.xchain_currencies[0])
+        issuing_chain_issue = _to_issued_currency(self.xchain_currencies[1])
+        return {
+            "LockingChainDoor": self.door_accounts[0],
+            "LockingChainIssue": locking_chain_issue,
+            "IssuingChainDoor": self.door_accounts[1],
+            "IssuingChainIssue": issuing_chain_issue,
+        }

--- a/sidechain_cli/utils/config_file/chain_config.py
+++ b/sidechain_cli/utils/config_file/chain_config.py
@@ -1,0 +1,46 @@
+"""Chain information stored in the CLI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from xrpl.clients import JsonRpcClient
+
+from sidechain_cli.utils.config_file.server_config import ServerConfig
+from sidechain_cli.utils.rippled_config import RippledConfig
+
+
+@dataclass
+class ChainConfig(ServerConfig):
+    """Object representing the config for a chain."""
+
+    ws_ip: str
+    ws_port: int
+
+    @property
+    def rippled(self: ChainConfig) -> str:
+        """
+        Get the rippled executable. Alias for `self.exe`.
+
+        Returns:
+            `self.exe`.
+        """
+        return self.exe
+
+    def get_client(self: ChainConfig) -> JsonRpcClient:
+        """
+        Get a client connected to the chain. Requires that the chain be running.
+
+        Returns:
+            A JsonRpcClient that is connected to this chain.
+        """
+        return JsonRpcClient(f"http://{self.http_ip}:{self.http_port}")
+
+    def get_config(self: ChainConfig) -> RippledConfig:
+        """
+        Get the config file for this chain.
+
+        Returns:
+            The RippledConfig object for this config file.
+        """
+        return RippledConfig(file_name=self.config)

--- a/sidechain_cli/utils/config_file/config_item.py
+++ b/sidechain_cli/utils/config_file/config_item.py
@@ -1,0 +1,23 @@
+"""Base class for information stored in the CLI."""
+
+from abc import ABC
+from typing import Any, Mapping, Type, TypeVar
+
+T = TypeVar("T", bound="ConfigItem")
+
+
+class ConfigItem(ABC):
+    """Abstract class representing a config item."""
+
+    @classmethod
+    def from_dict(cls: Type[T], data: Mapping[str, Any]) -> T:
+        """
+        Convert a dictionary to a given config object.
+
+        Args:
+            data: The dictionary to convert.
+
+        Returns:
+            The associated config object.
+        """
+        return cls(**data)

--- a/sidechain_cli/utils/config_file/server_config.py
+++ b/sidechain_cli/utils/config_file/server_config.py
@@ -1,0 +1,30 @@
+"""Server information stored in the CLI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Union
+
+from sidechain_cli.utils.config_file.config_item import ConfigItem
+
+
+@dataclass
+class ServerConfig(ConfigItem):
+    """Object representing the config for a server (chain/witness)."""
+
+    name: str
+    type: Union[Literal["rippled"], Literal["witness"]]
+    pid: int
+    exe: str
+    config: str
+    http_ip: str
+    http_port: int
+
+    def is_docker(self: ServerConfig) -> bool:
+        """
+        Return whether the server is running on docker.
+
+        Returns:
+            Whether the server is running on docker.
+        """
+        return self.exe == "docker"

--- a/sidechain_cli/utils/config_file/witness_config.py
+++ b/sidechain_cli/utils/config_file/witness_config.py
@@ -1,0 +1,34 @@
+"""Witness information stored in the CLI."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, cast
+
+from sidechain_cli.utils.config_file.server_config import ServerConfig
+
+
+@dataclass
+class WitnessConfig(ServerConfig):
+    """Object representing the config for a witness."""
+
+    @property
+    def witnessd(self: WitnessConfig) -> str:
+        """
+        Get the witnessd executable. Alias for `self.exe`.
+
+        Returns:
+            `self.exe`.
+        """
+        return self.exe
+
+    def get_config(self: WitnessConfig) -> Dict[str, Any]:
+        """
+        Get the config file for this witness.
+
+        Returns:
+            The JSON dictionary for this config file.
+        """
+        with open(self.config) as f:
+            return cast(Dict[str, Any], json.load(f))

--- a/tests/bridge/test_build.py
+++ b/tests/bridge/test_build.py
@@ -9,8 +9,10 @@ from xrpl.models import AccountObjects
 
 from sidechain_cli.main import main
 from sidechain_cli.utils import get_config
-from sidechain_cli.utils.config_file import _CONFIG_FILE
+from sidechain_cli.utils.config_file import get_config_folder
 from tests.utils import SetInterval, close_ledgers
+
+_CONFIG_FILE = os.path.join(get_config_folder(), "config.json")
 
 
 @pytest.mark.usefixtures("bridge_build_setup")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def pytest_configure(config):
 
         mocked_home_dir = tempfile.TemporaryDirectory()
         config_var = unittest.mock.patch(
-            "sidechain_cli.utils.config_file.CONFIG_FOLDER",
+            "sidechain_cli.utils.config_file.config_file.CONFIG_FOLDER",
             mocked_home_dir.name,
         )
         config_var.start()
@@ -56,7 +56,7 @@ def pytest_configure(config):
             data: Dict[str, List[Any]] = {"chains": [], "witnesses": [], "bridges": []}
             json.dump(data, f, indent=4)
         config_var2 = unittest.mock.patch(
-            "sidechain_cli.utils.config_file._CONFIG_FILE",
+            "sidechain_cli.utils.config_file.config_file._CONFIG_FILE",
             config_file,
         )
         config_var2.start()

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -12,7 +12,9 @@ import docker
 from sidechain_cli.main import main
 from sidechain_cli.server.start import _DOCKER_COMPOSE
 from sidechain_cli.utils import get_config
-from sidechain_cli.utils.config_file import CONFIG_FOLDER
+from sidechain_cli.utils.config_file import get_config_folder
+
+CONFIG_FOLDER = get_config_folder()
 
 
 @pytest.mark.usefixtures("runner")


### PR DESCRIPTION
## High Level Overview of Change

This PR moves everything related to the CLI config file into its own subfolder in `utils`, and splits each class into its own file.

### Context of Change

It's a lot easier to go through all the individual files instead of one big file.

### Type of Change
- [x] Refactor (non-breaking change that only restructures code)

## Test Plan

CI passes.
