### PR TITLE
fix: use the master key to submit bootstrap attestations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run tests
         id: runTests
         run: |
-          poetry run coverage run -m pytest -xsvv tests
+          poetry run coverage run -m pytest -svv tests
           poetry run coverage report
         env:
           RIPPLED_EXE: docker

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run tests
         id: runTests
         run: |
-          poetry run coverage run -m pytest -svv tests
+          poetry run coverage run -m pytest -xsvv tests
           poetry run coverage report
         env:
           RIPPLED_EXE: docker


### PR DESCRIPTION
## High Level Overview of Change

This PR removes the hacky code that added a signer list, and instead uses the master key to sign the bootstrap attestations.

### Context of Change

The rippled implementation was fixed to accept attestations written by the master key.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

CI passes.
