### PR TITLE
fix: fix witness config command

### DIFF
--- a/sidechain_cli/server/start.py
+++ b/sidechain_cli/server/start.py
@@ -158,7 +158,7 @@ def start_server(
     elif is_rippled:
         to_run = [exe, "--conf", config, "-a"]
     else:
-        to_run = [exe, "--config", config, "--verbose"]
+        to_run = [exe, "--conf", config, "--verbose"]
 
     process, output_file = _run_process(to_run, name)
 


### PR DESCRIPTION
## High Level Overview of Change

This PR changes the config command-line command for the witness server from `--config` to `--conf`, to match rippled.

### Context of Change

It was changed in the witness server.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Works locally.
